### PR TITLE
EnergyBoost properties added to FoodComponent

### DIFF
--- a/JSON_Templates/ModFoodComponent_Template.json
+++ b/JSON_Templates/ModFoodComponent_Template.json
@@ -70,6 +70,13 @@
 
                             "ContainsAlcohol" : false,
                             "AlcoholPercentage" : 0,
-                            "AlcoholUptakeMinutes" : 45
+                            "AlcoholUptakeMinutes" : 45,
+
+                            "AffectEnergyBoost" : false,
+                            "BoostDurationMinutes" : 0,
+                            "FatigueStartIncrease" : 0,
+                            "FatigueEndDecrease" : 0,
+                            "StaminaStartIncrease" : 0,
+                            "StaminaEndDecrease" : 0
                         }
 }

--- a/ModComponent/API/Components/ModFoodComponent.cs
+++ b/ModComponent/API/Components/ModFoodComponent.cs
@@ -64,10 +64,16 @@ public class ModFoodComponent : ModCookableComponent
 	/// </summary>
 	public float[] ParasiteRiskIncrements = Array.Empty<float>();
 
-	/// <summary>
-	/// Is the food item naturally occurring meat or plant?
-	/// </summary>
-	public bool Natural;
+    /// <summary>
+    /// When eaten, does the player consume all of it?
+    /// </summary>
+    public bool MustConsumeAll;
+
+    #region FoodTypeVariables
+    /// <summary>
+    /// Is the food item naturally occurring meat or plant?
+    /// </summary>
+    public bool Natural;
 
 	/// <summary>
 	/// Is the food item raw or cooked?
@@ -97,12 +103,14 @@ public class ModFoodComponent : ModCookableComponent
 	/// Canned items will yield a 'Recycled Can' when opened properly.
 	/// </summary>
 	public bool Canned;
+    #endregion
 
-	/// <summary>
-	/// Does this item require a tool for opening it?<br/>
-	/// If not enabled, the other settings in this section will be ignored.
-	/// </summary>
-	public bool Opening;
+    #region OpeningVariables
+    /// <summary>
+    /// Does this item require a tool for opening it?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool Opening;
 
 	/// <summary>
 	/// Can it be opened with a can opener?
@@ -123,12 +131,14 @@ public class ModFoodComponent : ModCookableComponent
 	/// Can it be opened by smashing?
 	/// </summary>
 	public bool OpeningWithSmashing;
+    #endregion
 
-	/// <summary>
-	/// Does this item affect 'Condition' while sleeping?<br/>
-	/// If not enabled, the other settings in this section will be ignored.
-	/// </summary>
-	public bool AffectCondition;
+    #region ConditionVariables
+    /// <summary>
+    /// Does this item affect 'Condition' while sleeping?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool AffectCondition;
 
 	/// <summary>
 	/// How much additional condition is restored per hour?
@@ -139,12 +149,14 @@ public class ModFoodComponent : ModCookableComponent
 	/// Amount of in-game minutes the 'ConditionRestBonus' will be applied.
 	/// </summary>
 	public float ConditionRestMinutes = 360;
+    #endregion
 
-	/// <summary>
-	/// Does this item affect 'Rest'?<br/>
-	/// If not enabled, the other settings in this section will be ignored.
-	/// </summary>
-	public bool AffectRest;
+    #region RestVariables
+    /// <summary>
+    /// Does this item affect 'Rest'?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool AffectRest;
 
 	/// <summary>
 	/// How much 'Rest' is restored/drained immediately after consuming the item.<br/>
@@ -157,12 +169,14 @@ public class ModFoodComponent : ModCookableComponent
 	/// Amount of in-game minutes the 'RestFactor' will be applied.
 	/// </summary>
 	public int RestFactorMinutes = 60;
+	#endregion
 
-	/// <summary>
-	/// Does this item affect 'Cold'?<br/>
-	/// If not enabled, the other settings in this section will be ignored.
-	/// </summary>
-	public bool AffectCold;
+    #region ColdVariables
+    /// <summary>
+    /// Does this item affect 'Cold'?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool AffectCold;
 
 	/// <summary>
 	/// How much 'Cold' is restored/drained immediately after consuming the item.<br/>
@@ -175,12 +189,14 @@ public class ModFoodComponent : ModCookableComponent
 	/// Amount of in-game minutes the 'ColdFactor' will be applied.
 	/// </summary>
 	public int ColdFactorMinutes = 60;
+    #endregion
 
-	/// <summary>
-	/// Does this item contain Alcohol?<br/>
-	/// If not enabled, the other settings in this section will be ignored.
-	/// </summary>
-	public bool ContainsAlcohol;
+    #region AlcoholVariables
+    /// <summary>
+    /// Does this item contain Alcohol?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool ContainsAlcohol;
 
 	/// <summary>
 	/// How much of the item's weight is alcohol?
@@ -194,8 +210,43 @@ public class ModFoodComponent : ModCookableComponent
 	/// Real-life value is around 45 mins for liquids.
 	/// </summary>
 	public float AlcoholUptakeMinutes = 45;
+    #endregion
 
-	void Awake()
+    #region EnergyVariables
+
+    /// <summary>
+    /// Does this item apply the 'Energy Boost' affliction?<br/>
+    /// If not enabled, the other settings in this section will be ignored.
+    /// </summary>
+    public bool AffectEnergyBoost;
+
+    /// <summary>
+    /// The amount of in-game minutes the 'EnergyBoost' affliction will be applied.
+    /// </summary>
+    public float BoostDurationMinutes;
+
+    /// <summary>
+    /// How much fatigue is taken from the player once the 'EnergyBoost' affliction runs out.
+    /// </summary>
+    public float FatigueEndingIncrease;
+
+    /// <summary>
+    /// How much fatigue is given to the player once the 'EnergyBoost' affliction is active.
+    /// </summary>
+    public float FatigueInitialDecrease;
+
+    /// <summary>
+    /// How much stamina is taken from the player once the 'EnergyBoost' affliction runs out.
+    /// </summary>
+    public float StaminaEndingDecrease;
+
+    /// <summary>
+    /// How much stamina is given to the player once the 'EnergyBoost' affliction is active.
+    /// </summary>
+    public float StaminaInitialIncrease;
+
+    #endregion
+    void Awake()
 	{
 		CopyFieldHandler.UpdateFieldValues(this);
 	}
@@ -249,5 +300,14 @@ public class ModFoodComponent : ModCookableComponent
 		this.ContainsAlcohol = dict.GetVariant(className, "ContainsAlcohol");
 		this.AlcoholPercentage = dict.GetVariant(className, "AlcoholPercentage");
 		this.AlcoholUptakeMinutes = dict.GetVariant(className, "AlcoholUptakeMinutes");
-	}
+
+        this.MustConsumeAll = dict.GetVariant(className, "MustConsumeAll");
+
+        this.AffectEnergyBoost = dict.GetVariant(className, "AffectEnergyBoost");
+        this.BoostDurationMinutes = dict.GetVariant(className, "BoostDurationMinutes");
+        this.FatigueEndingIncrease = dict.GetVariant(className, "FatigueStartIncrease");
+        this.FatigueInitialDecrease = dict.GetVariant(className, "FatigueEndDecrease");
+        this.StaminaEndingDecrease = dict.GetVariant(className, "StaminaStartIncrease");
+        this.StaminaInitialIncrease = dict.GetVariant(className, "StaminaEndDecrease");
+    }
 }

--- a/ModComponent/Mapper/BuffCauseTracker.cs
+++ b/ModComponent/Mapper/BuffCauseTracker.cs
@@ -43,6 +43,29 @@ internal static class FagtigueBuffApplyPatch
 	}
 }
 
+[HarmonyPatch(typeof(EnergyBoost), nameof(EnergyBoost.ApplyEnergyBoost))] // Changes EnergyBoost affliction to name of the GEAR_Item consumed.
+internal static class EnergyBoostApplyPatch
+{
+    public static void Postfix(EnergyBoost __instance, EnergyBoostItem energyBoostItem)
+    {
+        if (energyBoostItem == null)
+        {
+            return;
+        }
+
+        GearItem gearItem = energyBoostItem.m_GearItem;
+
+        if (gearItem == null)
+        {
+            return;
+        }
+        else
+        {
+            BuffCauseTracker.SetCause(AfflictionType.EnergyBoost, gearItem.DisplayName);
+        }
+    }
+}
+
 [HarmonyPatch(typeof(AfflictionButton), nameof(AfflictionButton.SetCauseAndEffect))]//positive caller count
 internal static class AfflictionButtonSetCauseAndEffectPatch
 {

--- a/ModComponent/Mapper/ComponentMappers/FoodMapper.cs
+++ b/ModComponent/Mapper/ComponentMappers/FoodMapper.cs
@@ -16,7 +16,7 @@ internal static class FoodMapper
 			return;
 		}
 
-		FoodItem foodItem = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<FoodItem>(modFoodComponent);
+		FoodItem foodItem = ComponentUtils.GetOrCreateComponent<FoodItem>(modFoodComponent);
 
 		foodItem.m_CaloriesTotal = modFoodComponent.Calories;
 		foodItem.m_CaloriesRemaining = modFoodComponent.Calories;
@@ -39,8 +39,8 @@ internal static class FoodMapper
 		foodItem.m_IsMeat = modFoodComponent.Meat;
 		foodItem.m_IsRawMeat = modFoodComponent.Raw;
 		foodItem.m_IsNatural = modFoodComponent.Natural;
-		foodItem.m_MustConsumeAll = false;
-		foodItem.m_ParasiteRiskPercentIncrease = ModComponent.Utils.ModUtils.NotNull(modFoodComponent.ParasiteRiskIncrements);
+		foodItem.m_MustConsumeAll = modFoodComponent.MustConsumeAll;
+        foodItem.m_ParasiteRiskPercentIncrease = ModUtils.NotNull(modFoodComponent.ParasiteRiskIncrements);
 
 		foodItem.m_PercentHeatLossPerMinuteIndoors = 1;
 		foodItem.m_PercentHeatLossPerMinuteOutdoors = 2;
@@ -54,7 +54,7 @@ internal static class FoodMapper
 
 			if (modFoodComponent.OpeningWithSmashing)
 			{
-				SmashableItem smashableItem = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<SmashableItem>(modFoodComponent);
+				SmashableItem smashableItem = ComponentUtils.GetOrCreateComponent<SmashableItem>(modFoodComponent);
 				smashableItem.m_MinPercentLoss = 10;
 				smashableItem.m_MaxPercentLoss = 30;
 				smashableItem.m_TimeToSmash = 6;
@@ -69,7 +69,7 @@ internal static class FoodMapper
 
 		if (modFoodComponent.AffectRest)
 		{
-			FatigueBuff fatigueBuff = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<FatigueBuff>(modFoodComponent);
+			FatigueBuff fatigueBuff = ComponentUtils.GetOrCreateComponent<FatigueBuff>(modFoodComponent);
 			fatigueBuff.m_InitialPercentDecrease = modFoodComponent.InstantRestChange;
 			fatigueBuff.m_RateOfIncreaseScale = 0.5f;
 			fatigueBuff.m_DurationHours = modFoodComponent.RestFactorMinutes / 60f;
@@ -77,7 +77,7 @@ internal static class FoodMapper
 
 		if (modFoodComponent.AffectCold)
 		{
-			FreezingBuff freezingBuff = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<FreezingBuff>(modFoodComponent);
+			FreezingBuff freezingBuff = ComponentUtils.GetOrCreateComponent<FreezingBuff>(modFoodComponent);
 			freezingBuff.m_InitialPercentDecrease = modFoodComponent.InstantColdChange;
 			freezingBuff.m_RateOfIncreaseScale = 0.5f;
 			freezingBuff.m_DurationHours = modFoodComponent.ColdFactorMinutes / 60f;
@@ -85,20 +85,32 @@ internal static class FoodMapper
 
 		if (modFoodComponent.AffectCondition)
 		{
-			ConditionRestBuff conditionRestBuff = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<ConditionRestBuff>(modFoodComponent);
+			ConditionRestBuff conditionRestBuff = ComponentUtils.GetOrCreateComponent<ConditionRestBuff>(modFoodComponent);
 			conditionRestBuff.m_ConditionRestBonus = modFoodComponent.ConditionRestBonus;
 			conditionRestBuff.m_NumHoursRestAffected = modFoodComponent.ConditionRestMinutes / 60f;
 		}
 
 		if (modFoodComponent.ContainsAlcohol)
 		{
-			AlcoholComponent alcohol = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<AlcoholComponent>(modFoodComponent);
+			AlcoholComponent alcohol = ComponentUtils.GetOrCreateComponent<AlcoholComponent>(modFoodComponent);
 			alcohol.AmountTotal = modFoodComponent.WeightKG * modFoodComponent.AlcoholPercentage * 0.01f;
 			alcohol.AmountRemaining = alcohol.AmountTotal;
 			alcohol.UptakeSeconds = modFoodComponent.AlcoholUptakeMinutes * 60;
 		}
 
-		HoverIconsToShow hoverIconsToShow = ModComponent.Utils.ComponentUtils.GetOrCreateComponent<HoverIconsToShow>(modFoodComponent);
+        if (modFoodComponent.AffectEnergyBoost)
+        {
+            EnergyBoostItem energyBoost = ComponentUtils.GetOrCreateComponent<EnergyBoostItem>(modFoodComponent);
+			energyBoost.m_BoostDurationHours = modFoodComponent.BoostDurationMinutes / 60f;
+            energyBoost.m_FatigueEndingIncrease = modFoodComponent.FatigueEndingIncrease;
+            energyBoost.m_FatigueInitialDecrease = modFoodComponent.FatigueInitialDecrease;
+			energyBoost.m_PulseFrequencyEnd = 1.2f;
+			energyBoost.m_PulseFrequencyStart = 0.8f;
+            energyBoost.m_StaminaEndingDecrease = modFoodComponent.StaminaEndingDecrease;
+            energyBoost.m_StaminaInitialIncrease = modFoodComponent.StaminaInitialIncrease;
+        }
+
+        HoverIconsToShow hoverIconsToShow = ComponentUtils.GetOrCreateComponent<HoverIconsToShow>(modFoodComponent);
 		hoverIconsToShow.m_HoverIcons = new HoverIconsToShow.HoverIcons[] { HoverIconsToShow.HoverIcons.Food };
 	}
 }

--- a/docs/Food-Component-Documentation.md
+++ b/docs/Food-Component-Documentation.md
@@ -74,7 +74,14 @@
 
                             "ContainsAlcohol" : false,
                             "AlcoholPercentage" : 0,
-                            "AlcoholUptakeMinutes" : 45
+                            "AlcoholUptakeMinutes" : 45,
+
+                            "AffectEnergyBoost" : false,
+                            "BoostDurationMinutes" : 0,
+                            "FatigueStartIncrease" : 0,
+                            "FatigueEndDecrease" : 0,
+                            "StaminaStartIncrease" : 0,
+                            "StaminaEndDecrease" : 0
                         }
 }
 ```
@@ -218,3 +225,27 @@ How much of the item's weight is alcohol?
 ## AlcoholUptakeMinutes
 *float*<br/>
 How many in-game minutes does it take for the alcohol to be fully absorbed? This is scaled by current hunger level (the hungrier the faster). The simulated blood alcohol level will slowly raise over this time. Real-life value is around 45 mins for liquids.
+
+## AffectEnergyBoost
+*bool*<br/>
+Does this item affect whether the 'EnergyBoost' affliction is applied to the player once consumed?
+
+## BoostDurationMinutes
+*float*<br/>
+Amount of in-game minutes the 'EnergyBoost' will be applied.
+
+## FatigueStartIncrease
+*float*<br/>
+How much 'Fatigue' is restored immediately after consuming the item. Represents change in percentage points. Negative values drain fatigue, positive values restore fatigue.
+
+## FatigueEndDecrease
+*float*<br/>
+How much 'Fatigue' is drained immediately after the 'EnergyBoost' affliction runs out. Represents change in percentage points. Negative values restore fatigue, positive values drain fatigue.
+
+## StaminaStartIncrease
+*float*<br/>
+How much 'Stamina' is restored immediately after consuming the item. Represents change in percentage points. Negative values drain stamina, positive values restore stamina.
+
+## StaminaEndDecrease
+*float*<br/>
+How much 'Stamina' is drained immediately after the 'EnergyBoost' affliction runs out. Represents change in percentage points. Negative values restore stamina, positive values drain stamina.


### PR DESCRIPTION
- Allows users to create energy drinks
- The ability to choose whether the player consumes the entire food or not with their custom food item
- Updated .json templates and docs to support these new parameters